### PR TITLE
Add NPC interface with health bars

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
-# bigbattle
-UI to handle a big battle against an army in DND that manages swarms and attack rolls. 
+# Big Battle
+
+A simple browser-based UI to manage large battles in D&D.
+
+## Usage
+
+Open `index.html` in a browser. Use the form at the top to add new NPC groups by
+specifying a name, how many NPCs are in the group and their maximum health. Each
+NPC appears in the grid with a health bar showing its current health.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,51 @@
+function createNpcElement(name, maxHealth) {
+    const npc = document.createElement('div');
+    npc.className = 'npc';
+    npc.dataset.health = maxHealth;
+    npc.dataset.maxHealth = maxHealth;
+
+    const title = document.createElement('div');
+    title.textContent = name;
+    npc.appendChild(title);
+
+    const bar = document.createElement('div');
+    bar.className = 'health-bar';
+
+    const barInner = document.createElement('div');
+    barInner.className = 'health-bar-inner';
+    bar.appendChild(barInner);
+
+    npc.appendChild(bar);
+
+    return npc;
+}
+
+function updateHealthBars() {
+    document.querySelectorAll('.npc').forEach(npc => {
+        const max = parseInt(npc.dataset.maxHealth, 10);
+        const current = parseInt(npc.dataset.health, 10);
+        const percentage = Math.max(0, current) / max * 100;
+        npc.querySelector('.health-bar-inner').style.width = percentage + '%';
+    });
+}
+
+function addNpcGroup() {
+    const name = document.getElementById('npc-name').value.trim();
+    const count = parseInt(document.getElementById('npc-count').value, 10) || 1;
+    const maxHealth = parseInt(document.getElementById('npc-health').value, 10) || 1;
+    if (!name) return;
+
+    const grid = document.getElementById('npc-grid');
+    for (let i = 0; i < count; i++) {
+        const npc = createNpcElement(name, maxHealth);
+        grid.appendChild(npc);
+    }
+    updateHealthBars();
+}
+
+function init() {
+    document.getElementById('add-npc').addEventListener('click', addNpcGroup);
+    updateHealthBars();
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/index.html
+++ b/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Big Battle</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>Big Battle</h1>
+    <div id="add-npc-form">
+        <h2>Add NPC Group</h2>
+        <label>Name: <input type="text" id="npc-name"></label>
+        <label>Count: <input type="number" id="npc-count" value="1" min="1"></label>
+        <label>Max Health: <input type="number" id="npc-health" value="10" min="1"></label>
+        <button id="add-npc">Add</button>
+    </div>
+    <div id="npc-grid" class="grid"></div>
+
+    <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,37 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 20px;
+}
+
+#add-npc-form {
+    margin-bottom: 20px;
+}
+
+#add-npc-form label {
+    margin-right: 10px;
+}
+
+.grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(120px, 1fr));
+    gap: 10px;
+}
+
+.npc {
+    border: 1px solid #ccc;
+    padding: 10px;
+    text-align: center;
+}
+
+.health-bar {
+    height: 10px;
+    background: #f44336;
+    margin-top: 5px;
+    position: relative;
+}
+
+.health-bar-inner {
+    height: 100%;
+    background: #4caf50;
+    width: 100%;
+}


### PR DESCRIPTION
## Summary
- create a small UI for Big Battle
- replace popup prompts with an interface for adding NPC groups
- display each NPC in a grid with a health bar

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6887848d89ec832390940303eded7654