### PR TITLE
Replace popup add group and handle damage

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -1,18 +1,6 @@
-document.getElementById('add-group-btn').addEventListener('click', () => {
-  const name = prompt('NPC Name', 'Darkrider');
-  const ac = prompt('AC', '10');
-  const hp = prompt('HP', '10');
-  const count = prompt('Count (max 25)', '5');
-  const damage_die = prompt('Damage Die (e.g., 1d6)', '1d6');
-  const damage_bonus = prompt('Damage Bonus', '0');
-  if (name && ac && hp && count) {
-    const form = document.createElement('form');
-    form.method = 'POST'; form.action = '/add_group';
-    [ ['name', name], ['ac', ac], ['hp', hp], ['count', count], ['damage_die', damage_die], ['damage_bonus', damage_bonus] ]
-      .forEach(([k,v]) => { let inp = document.createElement('input'); inp.type='hidden'; inp.name=k; inp.value=v; form.appendChild(inp); });
-    document.body.appendChild(form);
-    form.submit();
-  }
+document.getElementById('add-group-btn').addEventListener('click', (e) => {
+  e.preventDefault();
+  window.location.href = '/add_group';
 });
 
 // Delete handlers

--- a/templates/add_group.html
+++ b/templates/add_group.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Add NPC Group</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+  <div class="container">
+    <h1>Add NPC Group</h1>
+    <form action="{{ url_for('add_group') }}" method="post">
+      <label>Name: <input type="text" name="name" required></label><br>
+      <label>AC: <input type="number" name="ac" value="10" required></label><br>
+      <label>HP: <input type="number" name="hp" value="10" required></label><br>
+      <label>Count: <input type="number" name="count" value="1" min="1" max="25" required></label><br>
+      <label>Damage Die: <input type="text" name="damage_die" value="1d6"></label><br>
+      <label>Damage Bonus: <input type="number" name="damage_bonus" value="0"></label><br>
+      <button type="submit">Create Group</button>
+    </form>
+  </div>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,7 @@
 <body>
   <div class="container">
     <h1>Mass Battle Dashboard</h1>
-    <button id="add-group-btn">+ Add NPC Group</button>
+    <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
     <div id="groups">
       {% for g in groups %}
       <div class="group" id="group-{{ g.id }}">
@@ -24,11 +24,15 @@
         <div class="info">
           <h2>{{ g.name }}</h2>
           <p>HP: {{ g.hp }} &nbsp; AC: {{ g.ac }} &nbsp; Count: {{ g.count }}</p>
-          <form class="attack-form" action="{{ url_for('attack', group_id=g.id) }}" method="post">
-            <input type="number" name="target_ac" value="10" min="1" />
-            <button type="submit">Attack</button>
-          </form>
-          <button class="delete-btn" data-id="{{ g.id }}">Delete Group</button>
+            <form class="attack-form" action="{{ url_for('attack', group_id=g.id) }}" method="post">
+              <input type="number" name="target_ac" value="10" min="1" />
+              <button type="submit">Attack</button>
+            </form>
+            <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
+              <input type="number" name="damage" value="1" min="0" />
+              <button type="submit">Apply Damage</button>
+            </form>
+            <button class="delete-btn" data-id="{{ g.id }}">Delete Group</button>
           <form class="upload-form" action="{{ url_for('upload_icon', group_id=g.id) }}" method="post" enctype="multipart/form-data">
             <input type="file" name="icon" accept="image/*" />
             <button type="submit">Upload Icon</button>


### PR DESCRIPTION
## Summary
- add an `add_group.html` form
- update index to link to the new form and support damage application
- update JS to simply navigate to the new add group page
- handle damage logic on the backend with `individual_hp`

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a723d2dc8323be8bbc58a64b1140