### PR TITLE
NPC HP display improvements

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -4,8 +4,9 @@ body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
 .group { background: #3b3b3b; padding: 10px; border-radius: 8px; width: 300px; position: relative;
          animation: fadeIn 0.5s ease; }
 .grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 2px; }
-.cell { background: #1b1b1b; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; }
+.cell { background: #1b1b1b; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; position: relative; }
 .cell img { width: 32px; height: 32px; }
+.hp-label { position: absolute; top: -10px; left: 50%; transform: translateX(-50%); font-size: 12px; color: #fff; }
 .info { margin-top: 10px; }
 button { cursor: pointer; transition: transform 0.1s; }
 button:active { transform: scale(0.95); }

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,16 +14,17 @@
       {% for g in groups %}
       <div class="group" id="group-{{ g.id }}">
         <div class="grid">
-          {% for i in range(25) %}
+          {% for npc in g.npcs %}
           <div class="cell">
-            <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}" 
+            <span class="hp-label">{{ npc.hp }}</span>
+            <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
                  onerror="this.onerror=null;this.src='{{ url_for('static', filename='icons/default_icon.png') }}';" />
           </div>
           {% endfor %}
         </div>
         <div class="info">
           <h2>{{ g.name }}</h2>
-          <p>HP: {{ g.hp }} &nbsp; AC: {{ g.ac }} &nbsp; Count: {{ g.count }}</p>
+          <p>HP: {{ g.total_hp }} &nbsp; AC: {{ g.ac }} &nbsp; Count: {{ g.count }}</p>
             <form class="attack-form" action="{{ url_for('attack', group_id=g.id) }}" method="post">
               <input type="number" name="target_ac" value="10" min="1" />
               <button type="submit">Attack</button>


### PR DESCRIPTION
## Summary
- represent each NPC with its own HP via `NPC` dataclass
- calculate total HP per group and show correct count
- display only remaining NPC icons with an HP label above each
- style HP labels and tweak cell CSS

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887a98cff388323b74b368bb11b3856