### PR TITLE
Improve inline battle info

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -10,4 +10,10 @@ body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
 .info { margin-top: 10px; }
 button { cursor: pointer; transition: transform 0.1s; }
 button:active { transform: scale(0.95); }
+
+.attack-result { font-size: 14px; margin: 4px 0; }
+.player-ac { display: flex; align-items: center; gap: 4px; font-size: 14px; }
+.ac-btn { padding: 2px 6px; }
+.small-btn { font-size: 12px; padding: 2px 6px; }
+.file-input { font-size: 12px; }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -19,7 +19,34 @@ document.querySelectorAll('.attack-form').forEach(form => {
     fetch(form.action, { method: 'POST', body: new FormData(form) })
       .then(res => res.json())
       .then(data => {
-        alert(`${data.hits} hits, ${data.damage} total damage`);
+        const result = form.parentElement.querySelector('.attack-result');
+        if (result) {
+          result.textContent = `${data.hits} hits, ${data.damage} total damage`;
+        }
       });
+  });
+});
+
+// Player AC adjustment
+document.querySelectorAll('.ac-inc').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const span = btn.parentElement.querySelector('.ac-value');
+    span.textContent = parseInt(span.textContent, 10) + 1;
+  });
+});
+
+document.querySelectorAll('.ac-dec').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const span = btn.parentElement.querySelector('.ac-value');
+    span.textContent = Math.max(0, parseInt(span.textContent, 10) - 1);
+  });
+});
+
+// Auto upload icon when file chosen
+document.querySelectorAll('.upload-form input[type="file"]').forEach(input => {
+  input.addEventListener('change', () => {
+    if (input.files.length > 0) {
+      input.closest('form').submit();
+    }
   });
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -24,19 +24,24 @@
         </div>
         <div class="info">
           <h2>{{ g.name }}</h2>
-          <p>HP: {{ g.total_hp }} &nbsp; AC: {{ g.ac }} &nbsp; Count: {{ g.count }}</p>
-            <form class="attack-form" action="{{ url_for('attack', group_id=g.id) }}" method="post">
-              <input type="number" name="target_ac" value="10" min="1" />
-              <button type="submit">Attack</button>
-            </form>
-            <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
-              <input type="number" name="damage" value="1" min="0" />
-              <button type="submit">Apply Damage</button>
-            </form>
-            <button class="delete-btn" data-id="{{ g.id }}">Delete Group</button>
+          <p>HP: {{ g.total_hp }} &nbsp; Count: {{ g.count }}</p>
+          <form class="attack-form" action="{{ url_for('attack', group_id=g.id) }}" method="post">
+            <input type="number" name="target_ac" value="10" min="1" />
+            <button type="submit">Attack</button>
+          </form>
+          <div class="attack-result" id="result-{{ g.id }}"></div>
+          <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
+            <input type="number" name="damage" value="1" min="0" />
+            <button type="submit">Apply Damage</button>
+          </form>
+          <p class="player-ac">Player AC:
+            <button type="button" class="ac-btn ac-dec" data-id="{{ g.id }}">-</button>
+            <span class="ac-value">{{ g.ac }}</span>
+            <button type="button" class="ac-btn ac-inc" data-id="{{ g.id }}">+</button>
+          </p>
+          <button class="delete-btn small-btn" data-id="{{ g.id }}">Delete Group</button>
           <form class="upload-form" action="{{ url_for('upload_icon', group_id=g.id) }}" method="post" enctype="multipart/form-data">
-            <input type="file" name="icon" accept="image/*" />
-            <button type="submit">Upload Icon</button>
+            <input type="file" name="icon" accept="image/*" class="file-input" />
           </form>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- show attack results on each NPC group instead of alert
- allow player AC adjustments via +/- buttons
- shrink rarely-used controls and auto-upload icons

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887aff87e888323b05e5ad0d2c37871