### PR TITLE
Add attack customization and logs

### DIFF
--- a/app.py
+++ b/app.py
@@ -50,6 +50,8 @@ def add_group():
         "ac": int(data.get("ac", 10)),
         "damage_die": data.get("damage_die", "1d6"),
         "damage_bonus": int(data.get("damage_bonus", 0)),
+        "attack_name": data.get("attack_name", "Attack"),
+        "attack_die": data.get("attack_die", "1d20"),
         "icon": data.get("name", "default_icon") + ".png",
         "npcs": [NPC(base_hp) for _ in range(count)],
     }
@@ -96,14 +98,21 @@ def attack(group_id):
 
     hits = 0
     total_damage = 0
+    attack_die_count, attack_die_size = map(
+        int, group.get("attack_die", "1d20").lower().split("d")
+    )
     for _ in range(len(group.get("npcs", []))):
-        roll = random.randint(1, 20)
+        roll = sum(
+            random.randint(1, attack_die_size) for _ in range(attack_die_count)
+        )
         attack_total = roll + group["damage_bonus"]
         if attack_total >= target_ac:
             hits += 1
-            die_count, die_size = map(int, group["damage_die"].lower().split("d"))
+            dmg_die_count, dmg_die_size = map(
+                int, group["damage_die"].lower().split("d")
+            )
             dmg = (
-                sum(random.randint(1, die_size) for _ in range(die_count))
+                sum(random.randint(1, dmg_die_size) for _ in range(dmg_die_count))
                 + group["damage_bonus"]
             )
             total_damage += dmg

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -17,3 +17,7 @@ button:active { transform: scale(0.95); }
 .small-btn { font-size: 12px; padding: 2px 6px; }
 .file-input { font-size: 12px; }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
+
+#log-container { position: fixed; bottom: 10px; left: 50%; transform: translateX(-50%); width: 300px; }
+#log { background: #1b1b1b; border: 1px solid #555; padding: 4px; font-size: 12px; height: 3em; overflow-y: auto; }
+.attack-die { margin-left: 4px; font-size: 12px; }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -3,6 +3,18 @@ document.getElementById('add-group-btn').addEventListener('click', (e) => {
   window.location.href = '/add_group';
 });
 
+function addLog(text) {
+  const logBox = document.getElementById('log');
+  if (!logBox) return;
+  const div = document.createElement('div');
+  div.textContent = text;
+  logBox.appendChild(div);
+  logBox.scrollTop = logBox.scrollHeight;
+  while (logBox.children.length > 50) {
+    logBox.removeChild(logBox.firstChild);
+  }
+}
+
 // Delete handlers
 document.querySelectorAll('.delete-btn').forEach(btn => {
   btn.addEventListener('click', () => {
@@ -23,6 +35,9 @@ document.querySelectorAll('.attack-form').forEach(form => {
         if (result) {
           result.textContent = `${data.hits} hits, ${data.damage} total damage`;
         }
+        const groupName = form.dataset.groupName || 'Group';
+        const attackName = form.dataset.attackName || 'Attack';
+        addLog(`${groupName} ${attackName}: ${data.hits} hits for ${data.damage}`);
       });
   });
 });

--- a/templates/add_group.html
+++ b/templates/add_group.html
@@ -16,6 +16,8 @@
       <label>Count: <input type="number" name="count" value="1" min="1" max="25" required></label><br>
       <label>Damage Die: <input type="text" name="damage_die" value="1d6"></label><br>
       <label>Damage Bonus: <input type="number" name="damage_bonus" value="0"></label><br>
+      <label>Attack Name: <input type="text" name="attack_name" placeholder="Attack"></label><br>
+      <label>Attack Die: <input type="text" name="attack_die" value="1d20"></label><br>
       <button type="submit">Create Group</button>
     </form>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -25,9 +25,10 @@
         <div class="info">
           <h2>{{ g.name }}</h2>
           <p>Group Total HP: {{ g.total_hp }} &nbsp; NPCs Remaining: {{ g.count }}</p>
-          <form class="attack-form" action="{{ url_for('attack', group_id=g.id) }}" method="post">
+          <form class="attack-form" data-group-name="{{ g.name }}" data-attack-name="{{ g.attack_name }}" action="{{ url_for('attack', group_id=g.id) }}" method="post">
             <input type="number" name="target_ac" value="10" min="1" />
-            <button type="submit">Attack</button>
+            <button type="submit">{{ g.attack_name or 'Attack' }}</button>
+            <span class="attack-die">({{ g.attack_die }})</span>
           </form>
           <div class="attack-result" id="result-{{ g.id }}"></div>
           <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
@@ -47,6 +48,9 @@
       </div>
       {% endfor %}
     </div>
+  </div>
+  <div id="log-container">
+    <div id="log"></div>
   </div>
   <script src="{{ url_for('static', filename='js/script.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- allow specifying attack name and die when creating a group
- show the attack name and attack die in the group UI
- support custom attack roll dice in backend
- add small scrolling log area to view roll results
- log attack results on the page

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887b75944888323b6a9e4e6de22f7cb