### PR TITLE
Use player AC and attack bonus

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -28,7 +28,12 @@ document.querySelectorAll('.delete-btn').forEach(btn => {
 document.querySelectorAll('.attack-form').forEach(form => {
   form.addEventListener('submit', e => {
     e.preventDefault();
-    fetch(form.action, { method: 'POST', body: new FormData(form) })
+    const fd = new FormData(form);
+    const acSpan = form.parentElement.querySelector('.player-ac .ac-value');
+    if (acSpan) {
+      fd.append('target_ac', parseInt(acSpan.textContent, 10));
+    }
+    fetch(form.action, { method: 'POST', body: fd })
       .then(res => res.json())
       .then(data => {
         const result = form.parentElement.querySelector('.attack-result');
@@ -38,6 +43,9 @@ document.querySelectorAll('.attack-form').forEach(form => {
         const groupName = form.dataset.groupName || 'Group';
         const attackName = form.dataset.attackName || 'Attack';
         addLog(`${groupName} ${attackName}: ${data.hits} hits for ${data.damage}`);
+        if (Array.isArray(data.logs)) {
+          data.logs.forEach(l => addLog(l));
+        }
       });
   });
 });

--- a/templates/add_group.html
+++ b/templates/add_group.html
@@ -17,7 +17,7 @@
       <label>Damage Die: <input type="text" name="damage_die" value="1d6"></label><br>
       <label>Damage Bonus: <input type="number" name="damage_bonus" value="0"></label><br>
       <label>Attack Name: <input type="text" name="attack_name" placeholder="Attack"></label><br>
-      <label>Attack Die: <input type="text" name="attack_die" value="1d20"></label><br>
+      <label>Attack Bonus: <input type="number" name="attack_bonus" value="0"></label><br>
       <button type="submit">Create Group</button>
     </form>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -26,9 +26,8 @@
           <h2>{{ g.name }}</h2>
           <p>Group Total HP: {{ g.total_hp }} &nbsp; NPCs Remaining: {{ g.count }}</p>
           <form class="attack-form" data-group-name="{{ g.name }}" data-attack-name="{{ g.attack_name }}" action="{{ url_for('attack', group_id=g.id) }}" method="post">
-            <input type="number" name="target_ac" value="10" min="1" />
             <button type="submit">{{ g.attack_name or 'Attack' }}</button>
-            <span class="attack-die">({{ g.attack_die }})</span>
+            <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span>
           </form>
           <div class="attack-result" id="result-{{ g.id }}"></div>
           <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">


### PR DESCRIPTION
## Summary
- add an `attack_bonus` field when creating a group
- show player AC controls instead of a target AC input
- apply the player AC to attack calculations
- log each attack roll and damage roll

## Testing
- `python -m py_compile app.py`
- `node --check static/js/script.js`
- `python app.py` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6887bd0637c8832383ef61d7469f9689