### PR TITLE
Refactor group grid layout

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,13 +1,15 @@
 body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
 .container { max-width: 1200px; margin: auto; padding: 20px; }
-#groups { display: flex; flex-wrap: wrap; gap: 20px; }
-.group { background: #3b3b3b; padding: 10px; border-radius: 8px; width: 300px; position: relative;
-         animation: fadeIn 0.5s ease; }
+#groups { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }
+.group { background: #3b3b3b; padding: 6px; border-radius: 8px; width: 200px; position: relative;
+         animation: fadeIn 0.5s ease; transition: transform 0.2s; }
+.group:hover { transform: scale(1.05); }
 .grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: 2px; }
-.cell { background: #1b1b1b; width: 40px; height: 40px; display: flex; align-items: center; justify-content: center; position: relative; }
-.cell img { width: 32px; height: 32px; }
+.cell { background: #1b1b1b; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center; position: relative; }
+.cell img { width: 18px; height: 18px; }
 .hp-label { position: absolute; top: -10px; left: 50%; transform: translateX(-50%); font-size: 12px; color: #fff; }
 .info { margin-top: 10px; }
+.stats-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 button { cursor: pointer; transition: transform 0.1s; }
 button:active { transform: scale(0.95); }
 
@@ -16,6 +18,11 @@ button:active { transform: scale(0.95); }
 .ac-btn { padding: 2px 6px; }
 .small-btn { font-size: 12px; padding: 2px 6px; }
 .file-input { font-size: 12px; }
+/* three-dot menu */
+.menu { position: absolute; top: 4px; right: 4px; }
+.menu-btn { background: none; border: none; color: #fff; font-size: 16px; cursor: pointer; }
+.menu-content { display: none; position: absolute; right: 0; background: #444; border: 1px solid #666; padding: 4px; flex-direction: column; }
+.menu:hover .menu-content { display: flex; }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 
 #log-container { position: fixed; bottom: 10px; left: 50%; transform: translateX(-50%); width: 300px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,8 @@
       {% for g in groups %}
       <div class="group" id="group-{{ g.id }}">
         <div class="grid">
-          {% for npc in g.npcs %}
+          {% for i in range(g.count) %}
+          {% set npc = g.npcs[i] %}
           <div class="cell">
             <span class="hp-label">{{ npc.hp }}</span>
             <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
@@ -24,25 +25,32 @@
         </div>
         <div class="info">
           <h2>{{ g.name }}</h2>
-          <p>Group Total HP: {{ g.total_hp }} &nbsp; NPCs Remaining: {{ g.count }}</p>
-          <form class="attack-form" data-group-name="{{ g.name }}" data-attack-name="{{ g.attack_name }}" action="{{ url_for('attack', group_id=g.id) }}" method="post">
-            <button type="submit">{{ g.attack_name or 'Attack' }}</button>
-            <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span>
-          </form>
+          <div class="stats-row">
+            <span>HP {{ g.total_hp }} ({{ g.count }})</span>
+            <form class="attack-form" data-group-name="{{ g.name }}" data-attack-name="{{ g.attack_name }}" action="{{ url_for('attack', group_id=g.id) }}" method="post">
+              <button type="submit">{{ g.attack_name or 'Attack' }}</button>
+              <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span>
+            </form>
+            <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
+              <input type="number" name="damage" value="1" min="0" />
+              <button type="submit">DMG</button>
+            </form>
+            <p class="player-ac">AC:
+              <button type="button" class="ac-btn ac-dec" data-id="{{ g.id }}">-</button>
+              <span class="ac-value">{{ g.ac }}</span>
+              <button type="button" class="ac-btn ac-inc" data-id="{{ g.id }}">+</button>
+            </p>
+          </div>
           <div class="attack-result" id="result-{{ g.id }}"></div>
-          <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
-            <input type="number" name="damage" value="1" min="0" />
-            <button type="submit">Apply Damage</button>
-          </form>
-          <p class="player-ac">Player AC:
-            <button type="button" class="ac-btn ac-dec" data-id="{{ g.id }}">-</button>
-            <span class="ac-value">{{ g.ac }}</span>
-            <button type="button" class="ac-btn ac-inc" data-id="{{ g.id }}">+</button>
-          </p>
-          <button class="delete-btn small-btn" data-id="{{ g.id }}">Delete Group</button>
-          <form class="upload-form" action="{{ url_for('upload_icon', group_id=g.id) }}" method="post" enctype="multipart/form-data">
-            <input type="file" name="icon" accept="image/*" class="file-input" />
-          </form>
+          <div class="menu">
+            <button class="menu-btn" type="button">&#8942;</button>
+            <div class="menu-content">
+              <button class="delete-btn small-btn" data-id="{{ g.id }}">Delete Group</button>
+              <form class="upload-form" action="{{ url_for('upload_icon', group_id=g.id) }}" method="post" enctype="multipart/form-data">
+                <input type="file" name="icon" accept="image/*" class="file-input" />
+              </form>
+            </div>
+          </div>
         </div>
       </div>
       {% endfor %}


### PR DESCRIPTION
## Summary
- shrink HP cells and tighten group width
- display groups in a CSS grid
- loop over `range(g.count)` for grid cells
- show stats and attack options in one row
- move delete/upload into a three-dot menu with hover expand

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887c406acf08323800097c30e17513d