### PR TITLE
Add template saving and restore attack result label

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -10,6 +10,7 @@ body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
 .hp-label { position: absolute; top: -10px; left: 50%; transform: translateX(-50%); font-size: 12px; color: #fff; }
 .info { margin-top: 10px; }
 .stats-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
+.damage-form { display: inline-flex; align-items: center; gap: 4px; }
 button { cursor: pointer; transition: transform 0.1s; }
 button:active { transform: scale(0.95); }
 

--- a/static/js/add_group.js
+++ b/static/js/add_group.js
@@ -1,0 +1,27 @@
+const form = document.getElementById('group-form');
+const loadBtn = document.getElementById('load-template-btn');
+const saveBtn = document.getElementById('save-template-btn');
+const select = document.getElementById('template-select');
+
+if (loadBtn && select && form) {
+  loadBtn.addEventListener('click', () => {
+    const opt = select.options[select.selectedIndex];
+    if (!opt || !opt.dataset.name) return;
+    form.elements['name'].value = opt.dataset.name;
+    form.elements['ac'].value = opt.dataset.ac;
+    form.elements['hp'].value = opt.dataset.hp;
+    form.elements['count'].value = opt.dataset.count;
+    form.elements['damage_die'].value = opt.dataset.damage_die;
+    form.elements['damage_bonus'].value = opt.dataset.damage_bonus;
+    form.elements['attack_name'].value = opt.dataset.attack_name;
+    form.elements['attack_bonus'].value = opt.dataset.attack_bonus;
+  });
+}
+
+if (saveBtn && form) {
+  saveBtn.addEventListener('click', () => {
+    const fd = new FormData(form);
+    fetch('/save_template', { method: 'POST', body: fd })
+      .then(() => window.location.reload());
+  });
+}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -38,11 +38,11 @@ document.querySelectorAll('.attack-form').forEach(form => {
       .then(data => {
         const result = form.parentElement.querySelector('.attack-result');
         if (result) {
-          result.textContent = `${data.hits} hits, ${data.damage} total damage`;
+          result.textContent = `${data.hits} hits for a total of ${data.damage} damage`;
         }
         const groupName = form.dataset.groupName || 'Group';
         const attackName = form.dataset.attackName || 'Attack';
-        addLog(`${groupName} ${attackName}: ${data.hits} hits for ${data.damage}`);
+        addLog(`${groupName} ${attackName}: ${data.hits} hits for a total of ${data.damage} damage`);
         if (Array.isArray(data.logs)) {
           data.logs.forEach(l => addLog(l));
         }

--- a/templates/add_group.html
+++ b/templates/add_group.html
@@ -9,7 +9,16 @@
 <body>
   <div class="container">
     <h1>Add NPC Group</h1>
-    <form action="{{ url_for('add_group') }}" method="post">
+    <div class="template-load">
+      <select id="template-select">
+        <option value="">-- Load Template --</option>
+        {% for t in templates %}
+        <option value="{{ t.id }}" data-name="{{ t.name }}" data-ac="{{ t.ac }}" data-hp="{{ t.hp }}" data-count="{{ t.count }}" data-damage_die="{{ t.damage_die }}" data-damage_bonus="{{ t.damage_bonus }}" data-attack_name="{{ t.attack_name }}" data-attack_bonus="{{ t.attack_bonus }}">{{ t.name }}</option>
+        {% endfor %}
+      </select>
+      <button type="button" id="load-template-btn">Load</button>
+    </div>
+    <form id="group-form" action="{{ url_for('add_group') }}" method="post">
       <label>Name: <input type="text" name="name" required></label><br>
       <label>AC: <input type="number" name="ac" value="10" required></label><br>
       <label>HP: <input type="number" name="hp" value="10" required></label><br>
@@ -19,7 +28,9 @@
       <label>Attack Name: <input type="text" name="attack_name" placeholder="Attack"></label><br>
       <label>Attack Bonus: <input type="number" name="attack_bonus" value="0"></label><br>
       <button type="submit">Create Group</button>
+      <button type="button" id="save-template-btn">Save Template</button>
     </form>
   </div>
+  <script src="{{ url_for('static', filename='js/add_group.js') }}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show attack roll results in text as "hits for a total of X damage"
- keep damage field and DMG button on one line
- allow saving group creation values as templates in SQLite
- load templates on the add group page

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887cbd9d15c832394332f0db105968c