### PR TITLE
Fix attack label display and add nav bar

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,4 +1,6 @@
 body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
+.top-nav { display: flex; gap: 10px; margin-bottom: 10px; }
+.top-nav a { color: #f0f0f0; text-decoration: none; padding: 4px 8px; }
 .container { max-width: 1200px; margin: auto; padding: 20px; }
 #groups { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }
 .group { background: #3b3b3b; padding: 6px; border-radius: 8px; width: 200px; position: relative;
@@ -11,6 +13,9 @@ body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
 .info { margin-top: 10px; }
 .stats-row { display: flex; align-items: center; gap: 6px; flex-wrap: wrap; }
 .damage-form { display: inline-flex; align-items: center; gap: 4px; }
+.damage-form input[type="number"] {
+  width: 4ch;
+}
 button { cursor: pointer; transition: transform 0.1s; }
 button:active { transform: scale(0.95); }
 

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -36,7 +36,8 @@ document.querySelectorAll('.attack-form').forEach(form => {
     fetch(form.action, { method: 'POST', body: fd })
       .then(res => res.json())
       .then(data => {
-        const result = form.parentElement.querySelector('.attack-result');
+        const container = form.closest('.info');
+        const result = container ? container.querySelector('.attack-result') : null;
         if (result) {
           result.textContent = `${data.hits} hits for a total of ${data.damage} damage`;
         }

--- a/templates/index.html
+++ b/templates/index.html
@@ -9,7 +9,11 @@
 <body>
   <div class="container">
     <h1>Mass Battle Dashboard</h1>
-    <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
+    <nav class="top-nav">
+      <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
+      <a href="#" class="nav-link">Player View</a>
+      <a href="#" class="nav-link">Settings</a>
+    </nav>
     <div id="groups">
       {% for g in groups %}
       <div class="group" id="group-{{ g.id }}">


### PR DESCRIPTION
## Summary
- ensure attack result label is found correctly
- shrink damage input box
- convert `+ Add NPC Group` into a nav bar with placeholders

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6887d14b757c8323acc67437bf77c765