### PR TITLE
Add player view

### DIFF
--- a/app.py
+++ b/app.py
@@ -57,6 +57,13 @@ def index():
     return render_template("index.html", groups=npc_groups)
 
 
+@app.route('/player_view', methods=['GET'])
+def player_view():
+    for g in npc_groups:
+        g["count"] = len(g.get("npcs", []))
+    return render_template('player_view.html', groups=npc_groups)
+
+
 @app.route('/add_group', methods=['GET'])
 def add_group_page():
     conn = sqlite3.connect('saved_info.db')

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
     <h1>Mass Battle Dashboard</h1>
     <nav class="top-nav">
       <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
-      <a href="#" class="nav-link">Player View</a>
+      <a href="{{ url_for('player_view') }}" class="nav-link">Player View</a>
       <a href="#" class="nav-link">Settings</a>
     </nav>
     <div id="groups">

--- a/templates/player_view.html
+++ b/templates/player_view.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Player View</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+  <div class="container">
+    <h1>Player View</h1>
+    <nav class="top-nav">
+      <a href="{{ url_for('index') }}" class="nav-link">DM View</a>
+    </nav>
+    <div id="groups">
+      {% for g in groups %}
+      <div class="group" id="group-{{ g.id }}">
+        <div class="grid">
+          {% for _ in range(g.count) %}
+          <div class="cell">
+            <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
+                 onerror="this.onerror=null;this.src='{{ url_for('static', filename='icons/default_icon.png') }}';" />
+          </div>
+          {% endfor %}
+        </div>
+        <div class="info">
+          <h2>{{ g.name }}</h2>
+          <span>Enemies Remaining: {{ g.count }}</span>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- link to a new player view from the dashboard
- implement `player_view` route in Flask app
- add a simple `player_view.html` template showing only icon grids and enemy counts

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887d607681483238a5bc57f65053f6a