### PR TITLE
Add health bar and settings page

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -34,3 +34,16 @@ button:active { transform: scale(0.95); }
 #log-container { position: fixed; bottom: 10px; left: 50%; transform: translateX(-50%); width: 300px; }
 #log { background: #1b1b1b; border: 1px solid #555; padding: 4px; font-size: 12px; height: 3em; overflow-y: auto; }
 .attack-die { margin-left: 4px; font-size: 12px; }
+
+.hp-bar {
+  width: 100%;
+  height: 4px;
+  margin-top: 2px;
+  border-radius: 2px;
+}
+.hp-bar.green { background: #2ecc71; }
+.hp-bar.yellow { background: #f1c40f; }
+.hp-bar.orange { background: #e67e22; }
+.hp-bar.red { background: #e74c3c; }
+
+.settings-section { margin-bottom: 10px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -12,7 +12,7 @@
     <nav class="top-nav">
       <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
       <a href="{{ url_for('player_view') }}" class="nav-link">Player View</a>
-      <a href="#" class="nav-link">Settings</a>
+      <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
     </nav>
     <div id="groups">
       {% for g in groups %}
@@ -24,6 +24,10 @@
             <span class="hp-label">{{ npc.hp }}</span>
             <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
                  onerror="this.onerror=null;this.src='{{ url_for('static', filename='icons/default_icon.png') }}';" />
+            {% if settings.dm_view_health_bar %}
+            {% set pct = (npc.hp / npc.max_hp * 100) if npc.max_hp else 100 %}
+            <div class="hp-bar {{ 'green' if pct>=76 else 'yellow' if pct>=50 else 'orange' if pct>=25 else 'red' }}"></div>
+            {% endif %}
           </div>
           {% endfor %}
         </div>

--- a/templates/player_view.html
+++ b/templates/player_view.html
@@ -11,17 +11,22 @@
     <h1>Player View</h1>
     <nav class="top-nav">
       <a href="{{ url_for('index') }}" class="nav-link">DM View</a>
+      <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
     </nav>
     <div id="groups">
       {% for g in groups %}
       <div class="group" id="group-{{ g.id }}">
         <div class="grid">
-          {% for _ in range(g.count) %}
-          <div class="cell">
-            <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
-                 onerror="this.onerror=null;this.src='{{ url_for('static', filename='icons/default_icon.png') }}';" />
-          </div>
-          {% endfor %}
+      {% for npc in g.npcs %}
+      <div class="cell">
+        <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
+             onerror="this.onerror=null;this.src='{{ url_for('static', filename='icons/default_icon.png') }}';" />
+        {% if settings.player_view_health_bar %}
+        {% set pct = (npc.hp / npc.max_hp * 100) if npc.max_hp else 100 %}
+        <div class="hp-bar {{ 'green' if pct>=76 else 'yellow' if pct>=50 else 'orange' if pct>=25 else 'red' }}"></div>
+        {% endif %}
+      </div>
+      {% endfor %}
         </div>
         <div class="info">
           <h2>{{ g.name }}</h2>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Settings</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+  <div class="container">
+    <h1>Settings</h1>
+    <form action="{{ url_for('settings_page') }}" method="post">
+      <div class="settings-section">
+        <h2>DM View</h2>
+        <label><input type="checkbox" name="dm_view_health_bar" {% if settings.dm_view_health_bar %}checked{% endif %}> Show Health Bar</label>
+      </div>
+      <div class="settings-section">
+        <h2>Player View</h2>
+        <label><input type="checkbox" name="player_view_health_bar" {% if settings.player_view_health_bar %}checked{% endif %}> Show Health Bar</label>
+      </div>
+      <button type="submit">Save Settings</button>
+    </form>
+    <nav class="top-nav">
+      <a href="{{ url_for('index') }}">Back to DM View</a>
+    </nav>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- show icon health via color-coded bars
- configure health bar display from new settings page
- display bars on DM and player views

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887e65fad2c83239a8be686d599c8a8