### PR TITLE
Enhance log UI with dice rolls

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -31,9 +31,33 @@ button:active { transform: scale(0.95); }
 .menu:hover .menu-content { display: flex; }
 @keyframes fadeIn { from { opacity: 0; } to { opacity: 1; } }
 
-#log-container { position: fixed; bottom: 10px; left: 50%; transform: translateX(-50%); width: 300px; }
-#log { background: #1b1b1b; border: 1px solid #555; padding: 4px; font-size: 12px; height: 3em; overflow-y: auto; }
+#log-container {
+  position: fixed;
+  top: 10px;
+  bottom: 10px;
+  right: 10px;
+  width: 260px;
+  display: flex;
+}
+#log {
+  background: #1b1b1b;
+  border: 1px solid #555;
+  padding: 4px;
+  font-size: 10px;
+  overflow-y: auto;
+  flex: 1;
+}
 .attack-die { margin-left: 4px; font-size: 12px; }
+.adv-option { font-size: 12px; margin-right: 4px; }
+#dice-buttons {
+  display: flex;
+  flex-direction: column;
+  margin-right: 4px;
+}
+#dice-buttons .dice-btn {
+  margin-bottom: 2px;
+  font-size: 12px;
+}
 
 .hp-bar {
   width: 100%;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -74,3 +74,17 @@ document.querySelectorAll('.upload-form input[type="file"]').forEach(input => {
     }
   });
 });
+
+// Quick dice rolls
+document.querySelectorAll('#dice-buttons .dice-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const sides = parseInt(btn.dataset.die, 10);
+    const roll = Math.floor(Math.random() * sides) + 1;
+    const original = btn.textContent;
+    btn.textContent = roll;
+    addLog(`d${sides} roll: ${roll}`);
+    setTimeout(() => {
+      btn.textContent = original;
+    }, 10000);
+  });
+});

--- a/templates/index.html
+++ b/templates/index.html
@@ -38,7 +38,9 @@
             
 			<form class="attack-form" data-group-name="{{ g.name }}" data-attack-name="{{ g.attack_name }}" action="{{ url_for('attack', group_id=g.id) }}" method="post">
               <button type="submit">{{ g.attack_name or 'Attack' }}</button>
-              <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span>
+              <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span><br>
+              <label class="adv-option"><input type="checkbox" name="advantage">Adv</label>
+              <label class="adv-option"><input type="checkbox" name="disadvantage">DisAdv</label>
             </form>
             <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
               <input type="number" name="damage" value="1" min="0" />
@@ -66,6 +68,16 @@
     </div>
   </div>
   <div id="log-container">
+    <div id="dice-buttons">
+      <button class="dice-btn" data-die="20">d20</button>
+      <button class="dice-btn" data-die="100">d100</button>
+      <button class="dice-btn" data-die="12">d12</button>
+      <button class="dice-btn" data-die="10">d10</button>
+      <button class="dice-btn" data-die="8">d8</button>
+      <button class="dice-btn" data-die="6">d6</button>
+      <button class="dice-btn" data-die="4">d4</button>
+      <button class="dice-btn" data-die="2">d2</button>
+    </div>
     <div id="log"></div>
   </div>
   <script src="{{ url_for('static', filename='js/script.js') }}"></script>


### PR DESCRIPTION
## Summary
- move and resize DM log box to right side
- add quick dice roll buttons beside log
- add Adv/DisAdv checkboxes under each Attack button
- log quick dice roll results in JS

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887ecc8a9748323b9dc3a08b6ab025b