### PR TITLE
Add reach attack limit

### DIFF
--- a/app.py
+++ b/app.py
@@ -184,6 +184,9 @@ def attack(group_id):
     if not group:
         return jsonify({"error": "Group not found"}), 404
 
+    reach = "reach" in request.form
+    attack_limit = 10 if reach else 3
+
     hits = 0
     total_damage = 0
     logs = []
@@ -193,7 +196,7 @@ def attack(group_id):
     dmg_die_count, dmg_die_size = map(
         int, group["damage_die"].lower().split("d")
     )
-    for idx, _ in enumerate(group.get("npcs", []), start=1):
+    for idx, _ in enumerate(group.get("npcs", [])[:attack_limit], start=1):
         attack_rolls = [random.randint(1, attack_die_size) for _ in range(attack_die_count)]
         roll_total = sum(attack_rolls)
         attack_total = roll_total + group.get("attack_bonus", 0)

--- a/templates/index.html
+++ b/templates/index.html
@@ -41,6 +41,7 @@
               <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span><br>
               <label class="adv-option"><input type="checkbox" name="advantage">Adv</label>
               <label class="adv-option"><input type="checkbox" name="disadvantage">DisAdv</label>
+              <label class="adv-option"><input type="checkbox" name="reach">Reach</label>
             </form>
             <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
               <input type="number" name="damage" value="1" min="0" />


### PR DESCRIPTION
## Summary
- add a new Reach checkbox next to Adv and DisAdv
- cap number of attacks to 3 unless Reach is enabled, then allow 10

## Testing
- `python3 -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6888048bb4948323be0ec4c1d8fabf0b