### PR TITLE
Add NPC descriptions and log coloring

### DIFF
--- a/app.py
+++ b/app.py
@@ -110,6 +110,7 @@ def add_group():
         "id": next_id,
         "name": data.get("name", "Darkrider"),
         "ac": int(data.get("ac", 10)),
+        "description": data.get("description", ""),
         "damage_die": data.get("damage_die", "1d6"),
         "damage_bonus": int(data.get("damage_bonus", 0)),
         "attack_name": data.get("attack_name", "Attack"),

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -59,6 +59,10 @@ button:active { transform: scale(0.95); }
   font-size: 12px;
 }
 
+.log-npc { color: #9b59b6; }
+.log-player { color: #3498db; }
+.log-roll { color: #f1c40f; }
+
 .hp-bar {
   width: 100%;
   height: 4px;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -7,6 +7,13 @@ function addLog(text) {
   const logBox = document.getElementById('log');
   if (!logBox) return;
   const div = document.createElement('div');
+  if (/roll/i.test(text)) {
+    div.classList.add('log-roll');
+  } else if (/player/i.test(text)) {
+    div.classList.add('log-player');
+  } else {
+    div.classList.add('log-npc');
+  }
   div.textContent = text;
   logBox.appendChild(div);
   logBox.scrollTop = logBox.scrollHeight;

--- a/templates/add_group.html
+++ b/templates/add_group.html
@@ -27,6 +27,9 @@
       <label>Damage Bonus: <input type="number" name="damage_bonus" value="0"></label><br>
       <label>Attack Name: <input type="text" name="attack_name" placeholder="Attack"></label><br>
       <label>Attack Bonus: <input type="number" name="attack_bonus" value="0"></label><br>
+      <label>Description:<br>
+        <textarea name="description" rows="3" placeholder="Describe this NPC group"></textarea>
+      </label><br>
       <button type="submit">Create Group</button>
       <button type="button" id="save-template-btn">Save Template</button>
     </form>


### PR DESCRIPTION
## Summary
- allow entering NPC description on add-group page
- track description field in group data
- highlight log entries based on entry type

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68880790f3548323a7d00f4520414e20