### PR TITLE
Enable AI attack narration

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -46,11 +46,19 @@ document.querySelectorAll('.attack-form').forEach(form => {
         const container = form.closest('.info');
         const result = container ? container.querySelector('.attack-result') : null;
         if (result) {
-          result.textContent = `${data.hits} hits for a total of ${data.damage} damage`;
+          if (data.narration) {
+            result.textContent = data.narration;
+          } else {
+            result.textContent = `${data.hits} hits for a total of ${data.damage} damage`;
+          }
         }
         const groupName = form.dataset.groupName || 'Group';
         const attackName = form.dataset.attackName || 'Attack';
-        addLog(`${groupName} ${attackName}: ${data.hits} hits for a total of ${data.damage} damage`);
+        if (data.narration) {
+          addLog(data.narration);
+        } else {
+          addLog(`${groupName} ${attackName}: ${data.hits} hits for a total of ${data.damage} damage`);
+        }
         if (Array.isArray(data.logs)) {
           data.logs.forEach(l => addLog(l));
         }

--- a/templates/index.html
+++ b/templates/index.html
@@ -42,6 +42,7 @@
               <label class="adv-option"><input type="checkbox" name="advantage">Adv</label>
               <label class="adv-option"><input type="checkbox" name="disadvantage">DisAdv</label>
               <label class="adv-option"><input type="checkbox" name="reach">Reach</label>
+              <label class="adv-option"><input type="checkbox" name="ai">AI</label>
             </form>
             <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
               <input type="number" name="damage" value="1" min="0" />


### PR DESCRIPTION
## Summary
- add AI checkbox to choose narrative output
- incorporate OpenAI ChatGPT call in attack endpoint
- display returned narration instead of default text when AI is enabled

## Testing
- `python3 -m py_compile app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68880bdf48b083239e6b8fa840feea1c