### PR TITLE
Add OpenAI API key setting

### DIFF
--- a/templates/settings.html
+++ b/templates/settings.html
@@ -18,6 +18,12 @@
         <h2>Player View</h2>
         <label><input type="checkbox" name="player_view_health_bar" {% if settings.player_view_health_bar %}checked{% endif %}> Show Health Bar</label>
       </div>
+      <div class="settings-section">
+        <h2>OpenAI</h2>
+        <label>API Key:
+          <input type="password" name="openai_api_key" value="{{ settings.openai_api_key }}" placeholder="sk-...">
+        </label>
+      </div>
       <button type="submit">Save Settings</button>
     </form>
     <nav class="top-nav">


### PR DESCRIPTION
## Summary
- add `openai_api_key` to settings
- expose an API key field on the settings page
- load and update the OpenAI API key from settings

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68881335d8448323ab05e62f0fc1a8d9