### PR TITLE
Keep attack summary and log AI narrative

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -62,6 +62,7 @@ button:active { transform: scale(0.95); }
 .log-npc { color: #9b59b6; }
 .log-player { color: #3498db; }
 .log-roll { color: #f1c40f; }
+.log-narration { color: #ffffff; }
 
 .hp-bar {
   width: 100%;

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -7,7 +7,9 @@ function addLog(text) {
   const logBox = document.getElementById('log');
   if (!logBox) return;
   const div = document.createElement('div');
-  if (/roll/i.test(text)) {
+  if (/^Narration:/i.test(text)) {
+    div.classList.add('log-narration');
+  } else if (/roll/i.test(text)) {
     div.classList.add('log-roll');
   } else if (/player/i.test(text)) {
     div.classList.add('log-player');
@@ -46,11 +48,7 @@ document.querySelectorAll('.attack-form').forEach(form => {
         const container = form.closest('.info');
         const result = container ? container.querySelector('.attack-result') : null;
         if (result) {
-          if (data.narration) {
-            result.textContent = data.narration;
-          } else {
-            result.textContent = `${data.hits} hits for a total of ${data.damage} damage`;
-          }
+          result.textContent = `${data.hits} hits for a total of ${data.damage} damage`;
         }
         const groupName = form.dataset.groupName || 'Group';
         const attackName = form.dataset.attackName || 'Attack';


### PR DESCRIPTION
## Summary
- maintain the usual hit/damage summary in the attack result
- record AI-generated narration only in the log
- style narration log entries in white

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6888187ac2848323b2c74ba6800afc8d