### PR TITLE
Add template description, API key persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,4 @@ static/icons/default_icon.png
 uploads/default_icon.png
 uploads/darkrider.png
 static/icons/player.png
+thekey.py

--- a/static/js/add_group.js
+++ b/static/js/add_group.js
@@ -1,6 +1,7 @@
 const form = document.getElementById('group-form');
 const loadBtn = document.getElementById('load-template-btn');
 const saveBtn = document.getElementById('save-template-btn');
+const deleteBtn = document.getElementById('delete-template-btn');
 const select = document.getElementById('template-select');
 
 if (loadBtn && select && form) {
@@ -15,6 +16,7 @@ if (loadBtn && select && form) {
     form.elements['damage_bonus'].value = opt.dataset.damage_bonus;
     form.elements['attack_name'].value = opt.dataset.attack_name;
     form.elements['attack_bonus'].value = opt.dataset.attack_bonus;
+    form.elements['description'].value = opt.dataset.description || '';
   });
 }
 
@@ -22,6 +24,16 @@ if (saveBtn && form) {
   saveBtn.addEventListener('click', () => {
     const fd = new FormData(form);
     fetch('/save_template', { method: 'POST', body: fd })
+      .then(() => window.location.reload());
+  });
+}
+
+if (deleteBtn && select) {
+  deleteBtn.addEventListener('click', () => {
+    const opt = select.options[select.selectedIndex];
+    if (!opt || !opt.value) return;
+    if (!confirm('Delete this template?')) return;
+    fetch(`/delete_template/${opt.value}`, { method: 'POST' })
       .then(() => window.location.reload());
   });
 }

--- a/templates/add_group.html
+++ b/templates/add_group.html
@@ -13,10 +13,11 @@
       <select id="template-select">
         <option value="">-- Load Template --</option>
         {% for t in templates %}
-        <option value="{{ t.id }}" data-name="{{ t.name }}" data-ac="{{ t.ac }}" data-hp="{{ t.hp }}" data-count="{{ t.count }}" data-damage_die="{{ t.damage_die }}" data-damage_bonus="{{ t.damage_bonus }}" data-attack_name="{{ t.attack_name }}" data-attack_bonus="{{ t.attack_bonus }}">{{ t.name }}</option>
+        <option value="{{ t.id }}" data-name="{{ t.name }}" data-ac="{{ t.ac }}" data-hp="{{ t.hp }}" data-count="{{ t.count }}" data-damage_die="{{ t.damage_die }}" data-damage_bonus="{{ t.damage_bonus }}" data-attack_name="{{ t.attack_name }}" data-attack_bonus="{{ t.attack_bonus }}" data-description="{{ t.description }}">{{ t.name }}</option>
         {% endfor %}
       </select>
       <button type="button" id="load-template-btn">Load</button>
+      <button type="button" id="delete-template-btn">Delete</button>
     </div>
     <form id="group-form" action="{{ url_for('add_group') }}" method="post">
       <label>Name: <input type="text" name="name" required></label><br>


### PR DESCRIPTION
## Summary
- load API key from `thekey.py` if present and save to this file from settings
- add `description` field to templates table and include when saving/loading
- allow deleting saved templates via new route and button
- update front-end JS to handle description and template deletion
- ignore `thekey.py` in git

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_6888218691448323a33447765662e80e