### PR TITLE
Add session save/load/clear features

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -1,6 +1,8 @@
 body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
 .top-nav { display: flex; gap: 10px; margin-bottom: 10px; }
 .top-nav a { color: #f0f0f0; text-decoration: none; padding: 4px 8px; }
+.top-nav form { margin: 0; }
+.top-nav button { background: none; border: 1px solid #f0f0f0; color: #f0f0f0; padding: 4px 8px; }
 .container { max-width: 1200px; margin: auto; padding: 20px; }
 #groups { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }
 .group { background: #3b3b3b; padding: 6px; border-radius: 8px; width: 200px; position: relative;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,6 +13,9 @@
       <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
       <a href="{{ url_for('player_view') }}" class="nav-link">Player View</a>
       <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
+      <form action="{{ url_for('save_session') }}" method="post"><button type="submit">Save Session</button></form>
+      <form action="{{ url_for('load_session') }}" method="post"><button type="submit">Load Session</button></form>
+      <form action="{{ url_for('clear_session') }}" method="post"><button type="submit">Clear Session</button></form>
     </nav>
     <div id="groups">
       {% for g in groups %}


### PR DESCRIPTION
## Summary
- allow storing current battle session with new save/load/clear endpoints
- serialize npc group state and persist in sqlite
- add UI controls and styling for session management

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b5abcc5d8832398e03a5d34afdc25