### PR TITLE
Allow naming and selecting from multiple sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # bigbattle
-UI to handle a big battle against an army in DND that manages swarms and attack rolls. 
+UI to handle a big battle against an army in DND that manages swarms and attack rolls.
+
+## Session Management
+
+You can save the current battle state by providing a session name. Each save is timestamped and stored, allowing multiple sessions to be kept simultaneously. Use the **Load Session** page to pick from previously saved sessions and restore the game state.

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -2,6 +2,7 @@ body { font-family: sans-serif; background: #2b2b2b; color: #f0f0f0; }
 .top-nav { display: flex; gap: 10px; margin-bottom: 10px; }
 .top-nav a { color: #f0f0f0; text-decoration: none; padding: 4px 8px; }
 .top-nav form { margin: 0; }
+.top-nav form input { padding: 4px; }
 .top-nav button { background: none; border: 1px solid #f0f0f0; color: #f0f0f0; padding: 4px 8px; }
 .container { max-width: 1200px; margin: auto; padding: 20px; }
 #groups { display: grid; grid-template-columns: repeat(auto-fill, minmax(180px, 1fr)); gap: 12px; }

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,8 +13,11 @@
       <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
       <a href="{{ url_for('player_view') }}" class="nav-link">Player View</a>
       <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
-      <form action="{{ url_for('save_session') }}" method="post"><button type="submit">Save Session</button></form>
-      <form action="{{ url_for('load_session') }}" method="post"><button type="submit">Load Session</button></form>
+      <form action="{{ url_for('save_session') }}" method="post">
+        <input type="text" name="session_name" placeholder="Session Name" required>
+        <button type="submit">Save Session</button>
+      </form>
+      <a href="{{ url_for('load_session_page') }}" class="nav-link">Load Session</a>
       <form action="{{ url_for('clear_session') }}" method="post"><button type="submit">Clear Session</button></form>
     </nav>
     <div id="groups">

--- a/templates/load_session.html
+++ b/templates/load_session.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Load Session</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+  <div class="container">
+    <h1>Load Session</h1>
+    <nav class="top-nav">
+      <a href="{{ url_for('index') }}" class="nav-link">Home</a>
+    </nav>
+    <ul>
+      {% for s in sessions %}
+      <li>
+        {{ s.name }} ({{ s.saved_at }})
+        <form action="{{ url_for('load_session', session_id=s.id) }}" method="post" style="display:inline;">
+          <button type="submit">Load</button>
+        </form>
+      </li>
+      {% else %}
+      <li>No saved sessions</li>
+      {% endfor %}
+    </ul>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Store sessions with name and timestamp to enable multiple saved states
- Add UI to name sessions on save and select from list when loading
- Document session management and style the new input field

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689b5d778f00832390d9e0ecc1a6cad5