### PR TITLE
Prompt for session name on save

### DIFF
--- a/static/js/script.js
+++ b/static/js/script.js
@@ -3,6 +3,19 @@ document.getElementById('add-group-btn').addEventListener('click', (e) => {
   window.location.href = '/add_group';
 });
 
+const saveBtn = document.getElementById('save-session-btn');
+if (saveBtn) {
+  saveBtn.addEventListener('click', () => {
+    const name = prompt('Enter session name:');
+    if (name !== null) {
+      const fd = new FormData();
+      fd.append('session_name', name);
+      fetch('/save_session', { method: 'POST', body: fd })
+        .then(() => window.location.reload());
+    }
+  });
+}
+
 function addLog(text) {
   const logBox = document.getElementById('log');
   if (!logBox) return;

--- a/templates/index.html
+++ b/templates/index.html
@@ -13,10 +13,7 @@
       <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
       <a href="{{ url_for('player_view') }}" class="nav-link">Player View</a>
       <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
-      <form action="{{ url_for('save_session') }}" method="post">
-        <input type="text" name="session_name" placeholder="Session Name" required>
-        <button type="submit">Save Session</button>
-      </form>
+      <button id="save-session-btn" type="button">Save Session</button>
       <a href="{{ url_for('load_session_page') }}" class="nav-link">Load Session</a>
       <form action="{{ url_for('clear_session') }}" method="post"><button type="submit">Clear Session</button></form>
     </nav>


### PR DESCRIPTION
## Summary
- Prompt for a session name when the Save Session button is clicked, removing the need for a dedicated text field.
- Submit the entered name via fetch to save the session and reload the page.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b67f14fa88323a6173b0cf51aa451