### PR TITLE
Add ability score-based saving throws for NPC groups

### DIFF
--- a/app.py
+++ b/app.py
@@ -151,6 +151,14 @@ def add_group():
     data = request.form
     base_hp = int(data.get("hp", 1))
     count = int(data.get("count", 1))
+    abilities = {
+        "STR": int(data.get("str", 13)),
+        "DEX": int(data.get("dex", 13)),
+        "CON": int(data.get("con", 13)),
+        "INT": int(data.get("int", 13)),
+        "WIS": int(data.get("wis", 13)),
+        "CHA": int(data.get("cha", 13)),
+    }
     group = {
         "id": next_id,
         "name": data.get("name", "Darkrider"),
@@ -164,6 +172,7 @@ def add_group():
         "icon": data.get("name", "default_icon") + ".png",
         "base_hp": base_hp,
         "npcs": [NPC(base_hp, base_hp) for _ in range(count)],
+        "abilities": abilities,
     }
     npc_groups.append(group)
     next_id += 1
@@ -238,6 +247,14 @@ def _serialize_groups():
             'icon': g.get('icon', ''),
             'base_hp': g.get('base_hp', 1),
             'npcs': [{'hp': n.hp, 'max_hp': n.max_hp} for n in g.get('npcs', [])],
+            'abilities': g.get('abilities', {
+                'STR': 13,
+                'DEX': 13,
+                'CON': 13,
+                'INT': 13,
+                'WIS': 13,
+                'CHA': 13,
+            }),
         }
         for g in npc_groups
     ]
@@ -258,6 +275,14 @@ def _deserialize_groups(data):
             'icon': g.get('icon', ''),
             'base_hp': g.get('base_hp', 1),
             'npcs': [NPC(n['hp'], n.get('max_hp', n['hp'])) for n in g.get('npcs', [])],
+            'abilities': g.get('abilities', {
+                'STR': 13,
+                'DEX': 13,
+                'CON': 13,
+                'INT': 13,
+                'WIS': 13,
+                'CHA': 13,
+            }),
         }
         for g in data
     ]

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -28,6 +28,9 @@ button:active { transform: scale(0.95); }
 .ac-btn { padding: 2px 6px; }
 .small-btn { font-size: 12px; padding: 2px 6px; }
 .file-input { font-size: 12px; }
+.saves-row { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
+.save-dc { width: 4ch; }
+.save-result { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-weight: bold; pointer-events: none; }
 /* three-dot menu */
 .menu { position: absolute; top: 4px; right: 4px; }
 .menu-btn { background: none; border: none; color: #fff; font-size: 16px; cursor: pointer; }

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -179,3 +179,40 @@ document.querySelectorAll('#dice-buttons .dice-btn').forEach(btn => {
     }, 10000);
   });
 });
+
+// Saving throws for NPC groups
+document.querySelectorAll('.save-btn').forEach(btn => {
+  btn.addEventListener('click', () => {
+    const group = btn.closest('.group');
+    if (!group) return;
+    const ability = btn.dataset.ability;
+    const dcInput = group.querySelector('.save-dc');
+    const dc = parseInt(dcInput.value, 10) || 10;
+    const score = parseInt(group.dataset[ability.toLowerCase()], 10) || 13;
+    const modifier = Math.floor((score - 10) / 2);
+    const cells = group.querySelectorAll('.grid .cell');
+    let successes = 0;
+    cells.forEach(cell => {
+      const roll = Math.floor(Math.random() * 20) + 1;
+      const total = roll + modifier;
+      const success = total >= dc;
+      if (success) successes++;
+      let marker = cell.querySelector('.save-result');
+      if (!marker) {
+        marker = document.createElement('span');
+        marker.classList.add('save-result');
+        cell.appendChild(marker);
+      }
+      marker.textContent = success ? 'S' : 'F';
+      marker.style.color = success ? 'lime' : 'red';
+      if (cell._saveTimeout) clearTimeout(cell._saveTimeout);
+      cell._saveTimeout = setTimeout(() => {
+        marker.textContent = '';
+      }, 30000);
+    });
+    const nameEl = group.querySelector('h2');
+    const groupName = nameEl ? nameEl.textContent : 'Group';
+    addLog(`${groupName} ${ability} save vs DC ${dc}: ${successes}/${cells.length} succeed`);
+    addLog('----------');
+  });
+});

--- a/templates/add_group.html
+++ b/templates/add_group.html
@@ -28,6 +28,15 @@
       <label>Damage Bonus: <input type="number" name="damage_bonus" value="0"></label><br>
       <label>Attack Name: <input type="text" name="attack_name" placeholder="Attack"></label><br>
       <label>Attack Bonus: <input type="number" name="attack_bonus" value="0"></label><br>
+      <fieldset class="abilities">
+        <legend>Ability Scores</legend>
+        <label>STR: <input type="number" name="str" value="13"></label><br>
+        <label>DEX: <input type="number" name="dex" value="13"></label><br>
+        <label>CON: <input type="number" name="con" value="13"></label><br>
+        <label>INT: <input type="number" name="int" value="13"></label><br>
+        <label>WIS: <input type="number" name="wis" value="13"></label><br>
+        <label>CHA: <input type="number" name="cha" value="13"></label><br>
+      </fieldset>
       <label>Description:<br>
         <textarea name="description" rows="3" placeholder="Describe this NPC group"></textarea>
       </label><br>

--- a/templates/index.html
+++ b/templates/index.html
@@ -19,7 +19,7 @@
     </nav>
     <div id="groups">
       {% for g in groups %}
-      <div class="group" id="group-{{ g.id }}">
+      <div class="group" id="group-{{ g.id }}" data-str="{{ g.abilities['STR'] }}" data-dex="{{ g.abilities['DEX'] }}" data-con="{{ g.abilities['CON'] }}" data-int="{{ g.abilities['INT'] }}" data-wis="{{ g.abilities['WIS'] }}" data-cha="{{ g.abilities['CHA'] }}">
         <div class="grid">
           {% for i in range(g.count) %}
           {% set npc = g.npcs[i] %}
@@ -58,6 +58,15 @@
             </p>
           </div>
           <div class="attack-result" id="result-{{ g.id }}"></div>
+          <div class="saves-row">
+            <input type="number" class="save-dc" value="10" />
+            <button type="button" class="save-btn" data-ability="STR">STR</button>
+            <button type="button" class="save-btn" data-ability="DEX">DEX</button>
+            <button type="button" class="save-btn" data-ability="CON">CON</button>
+            <button type="button" class="save-btn" data-ability="INT">INT</button>
+            <button type="button" class="save-btn" data-ability="WIS">WIS</button>
+            <button type="button" class="save-btn" data-ability="CHA">CHA</button>
+          </div>
           <div class="menu">
             <button class="menu-btn" type="button">&#8942;</button>
             <div class="menu-content">


### PR DESCRIPTION
## Summary
- Track STR/DEX/CON/INT/WIS/CHA ability scores for NPC groups with default 13 values
- Add DC field and ability buttons on group tiles to roll saving throws
- Show success/fail markers on NPC icons and clear after 30 seconds

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689d9fafd64483239287dfbc34d18f50