### PR TITLE
Add clear log button and refine saving throw UI

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -29,6 +29,7 @@ button:active { transform: scale(0.95); }
 .small-btn { font-size: 12px; padding: 2px 6px; }
 .file-input { font-size: 12px; }
 .saves-row { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-top: 4px; }
+.saves-section h3 { margin: 4px 0 0 0; font-size: 14px; }
 .save-dc { width: 4ch; }
 .save-result { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); font-weight: bold; pointer-events: none; }
 /* three-dot menu */
@@ -46,6 +47,7 @@ button:active { transform: scale(0.95); }
   width: 260px;
   display: flex;
 }
+#log-column { flex: 1; display: flex; flex-direction: column; }
 #log {
   background: #1b1b1b;
   border: 1px solid #555;
@@ -54,6 +56,7 @@ button:active { transform: scale(0.95); }
   overflow-y: auto;
   flex: 1;
 }
+#clear-log-btn { margin-top: 4px; }
 .attack-die { margin-left: 4px; font-size: 12px; }
 .adv-option { font-size: 12px; margin-right: 4px; }
 #dice-buttons {

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -37,6 +37,16 @@ function addLog(text) {
   }
 }
 
+const clearLogBtn = document.getElementById('clear-log-btn');
+if (clearLogBtn) {
+  clearLogBtn.addEventListener('click', () => {
+    const logBox = document.getElementById('log');
+    if (logBox) {
+      logBox.innerHTML = '';
+    }
+  });
+}
+
 // Allow selecting NPC cells by clicking on them
 document.querySelectorAll('.group .grid .cell').forEach(cell => {
   cell.addEventListener('click', () => {

--- a/templates/index.html
+++ b/templates/index.html
@@ -43,7 +43,7 @@
               <button type="submit">{{ g.attack_name or 'Attack' }}</button>
               <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span><br>
               <label class="adv-option"><input type="checkbox" name="advantage">Adv</label>
-              <label class="adv-option"><input type="checkbox" name="disadvantage">DisAdv</label>
+              <label class="adv-option"><input type="checkbox" name="disadvantage">Dis</label>
               <label class="adv-option"><input type="checkbox" name="reach">Reach</label>
               <label class="adv-option"><input type="checkbox" name="ai">AI</label>
             </form>
@@ -58,14 +58,17 @@
             </p>
           </div>
           <div class="attack-result" id="result-{{ g.id }}"></div>
-          <div class="saves-row">
-            <input type="number" class="save-dc" value="10" />
-            <button type="button" class="save-btn" data-ability="STR">STR</button>
-            <button type="button" class="save-btn" data-ability="DEX">DEX</button>
-            <button type="button" class="save-btn" data-ability="CON">CON</button>
-            <button type="button" class="save-btn" data-ability="INT">INT</button>
-            <button type="button" class="save-btn" data-ability="WIS">WIS</button>
-            <button type="button" class="save-btn" data-ability="CHA">CHA</button>
+          <div class="saves-section">
+            <h3>Saving Throws</h3>
+            <div class="saves-row">
+              <label>Save DC <input type="number" class="save-dc" value="10" /></label>
+              <button type="button" class="save-btn" data-ability="STR">STR</button>
+              <button type="button" class="save-btn" data-ability="DEX">DEX</button>
+              <button type="button" class="save-btn" data-ability="CON">CON</button>
+              <button type="button" class="save-btn" data-ability="INT">INT</button>
+              <button type="button" class="save-btn" data-ability="WIS">WIS</button>
+              <button type="button" class="save-btn" data-ability="CHA">CHA</button>
+            </div>
           </div>
           <div class="menu">
             <button class="menu-btn" type="button">&#8942;</button>
@@ -92,7 +95,10 @@
       <button class="dice-btn" data-die="4">d4</button>
       <button class="dice-btn" data-die="2">d2</button>
     </div>
-    <div id="log"></div>
+    <div id="log-column">
+      <div id="log"></div>
+      <button id="clear-log-btn" type="button">Clear Log</button>
+    </div>
   </div>
   <script src="{{ url_for('static', filename='js/script.js') }}"></script>
 </body>


### PR DESCRIPTION
## Summary
- Add clear log control and layout container for log area
- Streamline disadvantage label and introduce "Saving Throws" section with labeled Save DC
- Style new elements and wire up clear-log logic

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689dadfaeb888323b0e7aaf8aab7a290