### PR TITLE
Enable CORS headers for static image requests

### DIFF
--- a/app.py
+++ b/app.py
@@ -26,6 +26,14 @@ ALLOWED_EXTENSIONS = {"png", "jpg", "jpeg", "gif"}
 app = Flask(__name__)
 app.config["UPLOAD_FOLDER"] = UPLOAD_FOLDER
 
+# Allow cross-origin requests so background images can be fetched
+# from this server by clients hosted on a different domain.
+@app.after_request
+def add_cors_headers(response):
+    """Add the headers necessary to permit cross-origin requests."""
+    response.headers["Access-Control-Allow-Origin"] = "*"
+    return response
+
 # In-memory store for npc groups.  Each group contains a list of NPC
 # instances which track their own hit points.
 npc_groups = []  # list of dicts


### PR DESCRIPTION
## Summary
- add an after_request hook that sets `Access-Control-Allow-Origin: *` so background images can be loaded cross-origin

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_689e5abd50fc832381d4a5936a5a2e7e