### PR TITLE
Add landing page and login gating for Seating Planet

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,12 +94,20 @@ def allowed_file(filename):
            filename.rsplit('.', 1)[1].lower() in ALLOWED_EXTENSIONS
 
 @app.route('/', methods=['GET'])
-def index():
+def home():
+    return render_template('index.html')
+
+@app.route('/seating', methods=['GET'])
+def seating():
+    return render_template('seating.html')
+
+@app.route('/battle', methods=['GET'])
+def battle():
     # Calculate total HP for each group before rendering
     for g in npc_groups:
         g["total_hp"] = sum(n.hp for n in g.get("npcs", []))
         g["count"] = len(g.get("npcs", []))
-    return render_template("index.html", groups=npc_groups, settings=settings)
+    return render_template("battle.html", groups=npc_groups, settings=settings)
 
 
 @app.route('/player_view', methods=['GET'])
@@ -176,7 +184,7 @@ def add_group():
     }
     npc_groups.append(group)
     next_id += 1
-    return redirect(url_for('index'))
+    return redirect(url_for('battle'))
 
 
 @app.route('/save_template', methods=['POST'])
@@ -207,7 +215,7 @@ def save_template():
 def delete_group(group_id):
     global npc_groups
     npc_groups = [g for g in npc_groups if g['id'] != group_id]
-    return redirect(url_for('index'))
+    return redirect(url_for('battle'))
 
 
 @app.route('/delete_template/<int:template_id>', methods=['POST'])
@@ -229,7 +237,7 @@ def upload_icon(group_id):
         for g in npc_groups:
             if g['id'] == group_id:
                 g['icon'] = filename
-    return redirect(url_for('index'))
+    return redirect(url_for('battle'))
 
 
 def _serialize_groups():
@@ -305,7 +313,7 @@ def save_session():
     )
     conn.commit()
     conn.close()
-    return redirect(url_for('index'))
+    return redirect(url_for('battle'))
 
 
 @app.route('/load_session', methods=['GET'])
@@ -334,7 +342,7 @@ def load_session(session_id):
         npc_groups = _deserialize_groups(data.get('npc_groups', []))
         next_id = data.get('next_id', 1)
         settings.update(data.get('settings', {}))
-    return redirect(url_for('index'))
+    return redirect(url_for('battle'))
 
 
 @app.route('/clear_session', methods=['POST'])
@@ -342,7 +350,7 @@ def clear_session():
     global npc_groups, next_id
     npc_groups = []
     next_id = 1
-    return redirect(url_for('index'))
+    return redirect(url_for('battle'))
 
 @app.route("/damage/<int:group_id>", methods=["POST"])
 def damage(group_id):

--- a/static/css/landing.css
+++ b/static/css/landing.css
@@ -1,0 +1,80 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: linear-gradient(135deg, #4facfe, #00f2fe);
+  color: #333;
+}
+
+.hero {
+  text-align: center;
+  margin-top: 50px;
+}
+
+.tagline {
+  font-size: 1.2rem;
+  margin-bottom: 20px;
+}
+
+.google-btn {
+  background: #4285F4;
+  color: white;
+  border: none;
+  padding: 10px 20px;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1rem;
+}
+
+.features {
+  max-width: 600px;
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  margin: 40px auto;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+}
+
+.features ul {
+  list-style-type: disc;
+  margin-left: 20px;
+}
+
+.apps {
+  margin-bottom: 40px;
+}
+
+.app-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-decoration: none;
+  background: white;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  color: #333;
+  transition: transform .2s;
+}
+
+.app-card:hover {
+  transform: scale(1.05);
+}
+
+.app-card .emoji {
+  font-size: 2rem;
+}
+
+.app-card .title {
+  margin-top: 10px;
+  font-size: 1.2rem;
+}
+
+.settings-note {
+  font-size: 0.9rem;
+  margin-top: 15px;
+}

--- a/static/js/landing.js
+++ b/static/js/landing.js
@@ -1,0 +1,25 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const loginBtn = document.getElementById('login-btn');
+  const seatingLink = document.getElementById('seating-link');
+
+  const updateButton = () => {
+    if (localStorage.getItem('loggedIn') === 'true') {
+      loginBtn.textContent = 'Logged in with Google';
+      loginBtn.disabled = true;
+    }
+  };
+
+  loginBtn.addEventListener('click', () => {
+    localStorage.setItem('loggedIn', 'true');
+    updateButton();
+  });
+
+  seatingLink.addEventListener('click', (e) => {
+    if (localStorage.getItem('loggedIn') !== 'true') {
+      e.preventDefault();
+      alert('Please log in with Google before visiting Seating Planet.');
+    }
+  });
+
+  updateButton();
+});

--- a/templates/battle.html
+++ b/templates/battle.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mass Battle Dashboard</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+</head>
+<body>
+  <div class="container">
+    <h1>Mass Battle Dashboard</h1>
+    <nav class="top-nav">
+      <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
+      <a href="{{ url_for('player_view') }}" class="nav-link">Player View</a>
+      <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
+      <button id="save-session-btn" type="button">Save Session</button>
+      <a href="{{ url_for('load_session_page') }}" class="nav-link">Load Session</a>
+      <form action="{{ url_for('clear_session') }}" method="post"><button type="submit">Clear Session</button></form>
+    </nav>
+    <div id="groups">
+      {% for g in groups %}
+      <div class="group" id="group-{{ g.id }}" data-str="{{ g.abilities['STR'] }}" data-dex="{{ g.abilities['DEX'] }}" data-con="{{ g.abilities['CON'] }}" data-int="{{ g.abilities['INT'] }}" data-wis="{{ g.abilities['WIS'] }}" data-cha="{{ g.abilities['CHA'] }}">
+        <div class="grid">
+          {% for i in range(g.count) %}
+          {% set npc = g.npcs[i] %}
+          <div class="cell" data-max-hp="{{ npc.max_hp }}" data-index="{{ i }}">
+            <span class="hp-label">{{ npc.hp }}</span>
+            <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
+                 onerror="this.onerror=null;this.src='{{ url_for('static', filename='icons/default_icon.png') }}';" />
+            {% if settings.dm_view_health_bar %}
+            {% set pct = (npc.hp / npc.max_hp * 100) if npc.max_hp else 100 %}
+            <div class="hp-bar {{ 'green' if pct>=76 else 'yellow' if pct>=50 else 'orange' if pct>=25 else 'red' }}"></div>
+            {% endif %}
+          </div>
+          {% endfor %}
+        </div>
+        <div class="info">
+          <h2>{{ g.name }}</h2>
+          <div class="stats-row">
+            <span>Total Group HP: {{ g.total_hp }} Enemies Remaining: {{ g.count }}</span>
+            
+			<form class="attack-form" data-group-name="{{ g.name }}" data-attack-name="{{ g.attack_name }}" action="{{ url_for('attack', group_id=g.id) }}" method="post">
+              <button type="submit">{{ g.attack_name or 'Attack' }}</button>
+              <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span><br>
+              <label class="adv-option"><input type="checkbox" name="advantage">Adv</label>
+              <label class="adv-option"><input type="checkbox" name="disadvantage">Dis</label>
+              <label class="adv-option"><input type="checkbox" name="reach">Reach</label>
+              <label class="adv-option"><input type="checkbox" name="ai">AI</label>
+            </form>
+            <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
+              <input type="number" name="damage" value="1" min="0" />
+              <button type="submit">Reduce Mob HP</button>
+            </form>
+            <p class="player-ac">Player AC:
+              <button type="button" class="ac-btn ac-dec" data-id="{{ g.id }}">-</button>
+              <span class="ac-value">{{ g.ac }}</span>
+              <button type="button" class="ac-btn ac-inc" data-id="{{ g.id }}">+</button>
+            </p>
+          </div>
+          <div class="attack-result" id="result-{{ g.id }}"></div>
+          <div class="saves-section">
+            <h3>Saving Throws</h3>
+            <div class="saves-row">
+              <label>Save DC <input type="number" class="save-dc" value="10" /></label>
+              <button type="button" class="save-btn" data-ability="STR">STR</button>
+              <button type="button" class="save-btn" data-ability="DEX">DEX</button>
+              <button type="button" class="save-btn" data-ability="CON">CON</button>
+              <button type="button" class="save-btn" data-ability="INT">INT</button>
+              <button type="button" class="save-btn" data-ability="WIS">WIS</button>
+              <button type="button" class="save-btn" data-ability="CHA">CHA</button>
+            </div>
+          </div>
+          <div class="menu">
+            <button class="menu-btn" type="button">&#8942;</button>
+            <div class="menu-content">
+              <button class="delete-btn small-btn" data-id="{{ g.id }}">Delete Group</button>
+              <form class="upload-form" action="{{ url_for('upload_icon', group_id=g.id) }}" method="post" enctype="multipart/form-data">
+                <input type="file" name="icon" accept="image/*" class="file-input" />
+              </form>
+            </div>
+          </div>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </div>
+  <div id="log-container">
+    <div id="dice-buttons">
+      <button class="dice-btn" data-die="20">d20</button>
+      <button class="dice-btn" data-die="100">d100</button>
+      <button class="dice-btn" data-die="12">d12</button>
+      <button class="dice-btn" data-die="10">d10</button>
+      <button class="dice-btn" data-die="8">d8</button>
+      <button class="dice-btn" data-die="6">d6</button>
+      <button class="dice-btn" data-die="4">d4</button>
+      <button class="dice-btn" data-die="2">d2</button>
+    </div>
+    <div id="log-column">
+      <div id="log"></div>
+      <button id="clear-log-btn" type="button">Clear Log</button>
+    </div>
+  </div>
+  <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+</body>
+</html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -3,103 +3,36 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Mass Battle Dashboard</title>
-  <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
+  <title>Fair Question</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/landing.css') }}">
 </head>
 <body>
-  <div class="container">
-    <h1>Mass Battle Dashboard</h1>
-    <nav class="top-nav">
-      <a id="add-group-btn" href="{{ url_for('add_group_page') }}">+ Add NPC Group</a>
-      <a href="{{ url_for('player_view') }}" class="nav-link">Player View</a>
-      <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
-      <button id="save-session-btn" type="button">Save Session</button>
-      <a href="{{ url_for('load_session_page') }}" class="nav-link">Load Session</a>
-      <form action="{{ url_for('clear_session') }}" method="post"><button type="submit">Clear Session</button></form>
+  <header class="hero">
+    <h1>Fair Question</h1>
+    <p class="tagline">A Google Classroom Seating Plan/Quiz App that is NOT BORING!</p>
+    <button id="login-btn" class="google-btn">Log in with Google</button>
+  </header>
+  <main>
+    <section class="features">
+      <h2>What does it do?</h2>
+      <ul>
+        <li>Loads your students from Google Classroom into a seating plan</li>
+        <li>A "Random Student" button for quiz questions</li>
+        <li>Dramatic music, sound effects</li>
+        <li>Reads out students names in a dramatic British AI voice</li>
+        <li>Hand picked organic reaction gifs to entertain!</li>
+        <li>Keeps track of points!</li>
+        <li>Custom Backgrounds!</li>
+      </ul>
+      <p class="settings-note">You can enable or disable these features in settings (as well as make audio clips for student names).</p>
+    </section>
+    <nav class="apps">
+      <a id="seating-link" href="{{ url_for('seating') }}" class="app-card">
+        <span class="emoji">🪑</span>
+        <span class="title">Seating Planet</span>
+      </a>
     </nav>
-    <div id="groups">
-      {% for g in groups %}
-      <div class="group" id="group-{{ g.id }}" data-str="{{ g.abilities['STR'] }}" data-dex="{{ g.abilities['DEX'] }}" data-con="{{ g.abilities['CON'] }}" data-int="{{ g.abilities['INT'] }}" data-wis="{{ g.abilities['WIS'] }}" data-cha="{{ g.abilities['CHA'] }}">
-        <div class="grid">
-          {% for i in range(g.count) %}
-          {% set npc = g.npcs[i] %}
-          <div class="cell" data-max-hp="{{ npc.max_hp }}" data-index="{{ i }}">
-            <span class="hp-label">{{ npc.hp }}</span>
-            <img src="{{ url_for('static', filename='icons/' + (g.icon if g.icon else 'default_icon.png')) }}"
-                 onerror="this.onerror=null;this.src='{{ url_for('static', filename='icons/default_icon.png') }}';" />
-            {% if settings.dm_view_health_bar %}
-            {% set pct = (npc.hp / npc.max_hp * 100) if npc.max_hp else 100 %}
-            <div class="hp-bar {{ 'green' if pct>=76 else 'yellow' if pct>=50 else 'orange' if pct>=25 else 'red' }}"></div>
-            {% endif %}
-          </div>
-          {% endfor %}
-        </div>
-        <div class="info">
-          <h2>{{ g.name }}</h2>
-          <div class="stats-row">
-            <span>Total Group HP: {{ g.total_hp }} Enemies Remaining: {{ g.count }}</span>
-            
-			<form class="attack-form" data-group-name="{{ g.name }}" data-attack-name="{{ g.attack_name }}" action="{{ url_for('attack', group_id=g.id) }}" method="post">
-              <button type="submit">{{ g.attack_name or 'Attack' }}</button>
-              <span class="attack-die">(1d20{% if g.attack_bonus %}+{{ g.attack_bonus }}{% endif %})</span><br>
-              <label class="adv-option"><input type="checkbox" name="advantage">Adv</label>
-              <label class="adv-option"><input type="checkbox" name="disadvantage">Dis</label>
-              <label class="adv-option"><input type="checkbox" name="reach">Reach</label>
-              <label class="adv-option"><input type="checkbox" name="ai">AI</label>
-            </form>
-            <form class="damage-form" action="{{ url_for('damage', group_id=g.id) }}" method="post">
-              <input type="number" name="damage" value="1" min="0" />
-              <button type="submit">Reduce Mob HP</button>
-            </form>
-            <p class="player-ac">Player AC:
-              <button type="button" class="ac-btn ac-dec" data-id="{{ g.id }}">-</button>
-              <span class="ac-value">{{ g.ac }}</span>
-              <button type="button" class="ac-btn ac-inc" data-id="{{ g.id }}">+</button>
-            </p>
-          </div>
-          <div class="attack-result" id="result-{{ g.id }}"></div>
-          <div class="saves-section">
-            <h3>Saving Throws</h3>
-            <div class="saves-row">
-              <label>Save DC <input type="number" class="save-dc" value="10" /></label>
-              <button type="button" class="save-btn" data-ability="STR">STR</button>
-              <button type="button" class="save-btn" data-ability="DEX">DEX</button>
-              <button type="button" class="save-btn" data-ability="CON">CON</button>
-              <button type="button" class="save-btn" data-ability="INT">INT</button>
-              <button type="button" class="save-btn" data-ability="WIS">WIS</button>
-              <button type="button" class="save-btn" data-ability="CHA">CHA</button>
-            </div>
-          </div>
-          <div class="menu">
-            <button class="menu-btn" type="button">&#8942;</button>
-            <div class="menu-content">
-              <button class="delete-btn small-btn" data-id="{{ g.id }}">Delete Group</button>
-              <form class="upload-form" action="{{ url_for('upload_icon', group_id=g.id) }}" method="post" enctype="multipart/form-data">
-                <input type="file" name="icon" accept="image/*" class="file-input" />
-              </form>
-            </div>
-          </div>
-        </div>
-      </div>
-      {% endfor %}
-    </div>
-  </div>
-  <div id="log-container">
-    <div id="dice-buttons">
-      <button class="dice-btn" data-die="20">d20</button>
-      <button class="dice-btn" data-die="100">d100</button>
-      <button class="dice-btn" data-die="12">d12</button>
-      <button class="dice-btn" data-die="10">d10</button>
-      <button class="dice-btn" data-die="8">d8</button>
-      <button class="dice-btn" data-die="6">d6</button>
-      <button class="dice-btn" data-die="4">d4</button>
-      <button class="dice-btn" data-die="2">d2</button>
-    </div>
-    <div id="log-column">
-      <div id="log"></div>
-      <button id="clear-log-btn" type="button">Clear Log</button>
-    </div>
-  </div>
-  <script src="{{ url_for('static', filename='js/script.js') }}"></script>
+  </main>
+  <script src="{{ url_for('static', filename='js/landing.js') }}"></script>
 </body>
 </html>

--- a/templates/load_session.html
+++ b/templates/load_session.html
@@ -10,7 +10,7 @@
   <div class="container">
     <h1>Load Session</h1>
     <nav class="top-nav">
-      <a href="{{ url_for('index') }}" class="nav-link">Home</a>
+      <a href="{{ url_for('battle') }}" class="nav-link">Home</a>
     </nav>
     <ul>
       {% for s in sessions %}

--- a/templates/player_view.html
+++ b/templates/player_view.html
@@ -10,7 +10,7 @@
   <div class="container">
     <h1>Player View</h1>
     <nav class="top-nav">
-      <a href="{{ url_for('index') }}" class="nav-link">DM View</a>
+      <a href="{{ url_for('battle') }}" class="nav-link">DM View</a>
       <a href="{{ url_for('settings_page') }}" class="nav-link">Settings</a>
     </nav>
     <div id="groups">

--- a/templates/seating.html
+++ b/templates/seating.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Seating Planet</title>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/landing.css') }}">
+</head>
+<body>
+  <h1>Seating Planet</h1>
+  <p>Welcome to Seating Planet!</p>
+</body>
+</html>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -27,7 +27,7 @@
       <button type="submit">Save Settings</button>
     </form>
     <nav class="top-nav">
-      <a href="{{ url_for('index') }}">Back to DM View</a>
+      <a href="{{ url_for('battle') }}">Back to DM View</a>
     </nav>
   </div>
 </body>


### PR DESCRIPTION
## Summary
- Add a styled landing page that introduces Fair Question and links to the Seating Planet app
- Require a simulated Google login before allowing navigation to Seating Planet
- Move original battle dashboard to `/battle` and update templates to point to it

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689e70397c0083239a743aa36cde8c58